### PR TITLE
Include version in the url

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -7,7 +7,7 @@ require "formula"
 class WerckerCli < Formula
   desc "wercker command line interface for building and running containers"
   homepage "http://wercker.com"
-  url "https://s3.amazonaws.com/downloads.wercker.com/cli/stable/darwin_amd64/wercker"
+  url "https://s3.amazonaws.com/downloads.wercker.com/cli/versions/$VERSION/darwin_amd64/wercker"
   sha256 "$SHA256"
   version "$VERSION"
 


### PR DESCRIPTION
This ensures that the user will get the correct binary, even if updates got released.