### PR TITLE
Rename downloads.wercker.com to wercker

### DIFF
--- a/wercker-cli.template.rb
+++ b/wercker-cli.template.rb
@@ -16,5 +16,9 @@ class WerckerCli < Formula
 
   def install
     bin.install Dir["*"]
+    file = "#{prefix}/bin/downloads.wercker.com"
+    if File.file?(file) 
+      File.rename(file, "#{prefix}/bin/wercker")
+    end
   end
 end

--- a/wercker-cli.template.rb
+++ b/wercker-cli.template.rb
@@ -1,24 +1,18 @@
-require "formula"
-
 class WerckerCli < Formula
-  desc "wercker command line interface for building and running containers"
+  desc "Wercker command-line interface for building and running containers"
   homepage "http://wercker.com"
 
-  url "https://s3.amazonaws.com/downloads.wercker.com/cli/versions/${STABLE_VERSION}/darwin_amd64/wercker"
+  url "http://downloads.wercker.com/cli/versions/${STABLE_VERSION}/darwin_amd64/wercker", :using => :nounzip
   sha256 "${STABLE_SHA256}"
-  version "${STABLE_VERSION}"
 
-  devel do
-    url "https://s3.amazonaws.com/downloads.wercker.com/cli/versions/${BETA_VERSION}/darwin_amd64/wercker"
-    sha256 "${BETA_SHA256}"
-    version "${BETA_VERSION}"
-  end
+  # Version information for quick reference
+  # version "${STABLE_VERSION}"
 
   def install
-    bin.install Dir["*"]
-    file = "#{prefix}/bin/downloads.wercker.com"
-    if File.file?(file) 
-      File.rename(file, "#{prefix}/bin/wercker")
-    end
+    bin.install "wercker"
+  end
+
+  test do
+    system "#{bin}/wercker version"
   end
 end


### PR DESCRIPTION
~I'm not sure when the issue with the incorrect name was introduced, but it's probably a change on the homebrew side. For this reason, i've added a check to see if the `downloads.wercker.com` file exists, and only then rename.~

~A different solution would be to download the cli as a tarball, which what most homebrew formula's do~

I've switched the url to use downloads.wercker.com and modified the file inline with the hints from `brew audit`

fixes #12 